### PR TITLE
Important fix, improves getting clear text except html from clipboard.

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -20,9 +20,9 @@
     },
     'ru-RU': {
       cleaner: {
-        tooltip: 'Cleaner',
-        not: 'Text has been Cleaned!!!',
-        limitText: 'Text',
+        tooltip: 'Очистка HTML',
+        not: 'Текст был очищен!!!',
+        limitText: 'Текст',
         limitHTML: 'HTML'
         }
     }

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -167,8 +167,12 @@
             var ffox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
             if (msie)
               var text = window.clipboardData.getData("Text");
-            else
-              var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'text/html' : 'text/plain');
+            else {
+                if (options.cleaner.keepHtml && e.originalEvent.clipboardData.types[1] == 'text/html')
+                    var text = e.originalEvent.clipboardData.getData('text/html');
+                else
+                    var text = e.originalEvent.clipboardData.getData('text/plain');
+            }
             if (text) {
               if (msie || ffox)
                 setTimeout($note.summernote('pasteHTML', cleanText(text, options.cleaner.newline)), 1);

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -17,6 +17,14 @@
         limitText: 'Text',
         limitHTML: 'HTML'
       }
+    },
+    'ru-RU': {
+      cleaner: {
+        tooltip: 'Cleaner',
+        not: 'Text has been Cleaned!!!',
+        limitText: 'Text',
+        limitHTML: 'HTML'
+        }
     }
   });
   $.extend($.summernote.options, {

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -160,7 +160,7 @@
             if (msie)
               var text = window.clipboardData.getData("Text");
             else
-              var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'Text' : 'text/plain');
+              var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'text/html' : 'text/plain');
             if (text) {
               if (msie || ffox)
                 setTimeout($note.summernote('pasteHTML', cleanText(text, options.cleaner.newline)), 1);


### PR DESCRIPTION
I dont know how long ago, but now is important to define full content type of clipboardData.getData.
If format is 'Text' - this method will return plain text instead of html.